### PR TITLE
fix 2 issues

### DIFF
--- a/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
+++ b/core/src/main/java/kafka/server/RemoteClusterMetadataManager.java
@@ -140,7 +140,7 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
                         metrics,
                         time,
                         brokerEndpoint.id(),
-                        "broker-" + nodeId + "-remote-cluster-metadata-manager-" + k,
+                        "broker-" + nodeId + "-remote-cluster-metadata-manager-" + k.replace(":", "-"),
                         logContext
                     );
                 });
@@ -192,7 +192,8 @@ public class RemoteClusterMetadataManager implements AutoCloseable {
                         partitionLeaders.put(partitionMetadata.topicPartition, remoteClusterNodes.get(remoteBootstrapServers).get(partitionMetadata.leaderId.get()));
                     });
 
-                    if (metadataImage.topics().getTopic(topicMetadata.topicId()).partitions().size() < partitionLeaders.size()) {
+                    if (metadataImage.topics().getTopic(topicMetadata.topicId()) != null &&
+                            metadataImage.topics().getTopic(topicMetadata.topicId()).partitions().size() < partitionLeaders.size()) {
                         createPartitionsTopics.add(new CreatePartitionsRequestData.CreatePartitionsTopic()
                             .setName(topicMetadata.topic())
                             .setCount(partitionLeaders.size())


### PR DESCRIPTION
1. Error when registering metrics because we have `:` in the metric name:
```
!!! Registering mbean for metricName MetricName [name=connection-close-total, group=remote-readonly-broker-4-remote-cluster-metadata-manager-localhost:9092-metrics, description=The total number of connections closed, tags={}], kafka.server, kafka.server:type=remote-readonly-broker-4-remote-cluster-metadata-manager-localhost:9092-metrics (org.apache.kafka.common.metrics.JmxReporter)

[2025-09-03 17:23:24,030] ERROR Error when registering metric on org.apache.kafka.common.metrics.JmxReporter (org.apache.kafka.common.metrics.Metrics)
org.apache.kafka.common.KafkaException: Error creating mbean attribute for metricName :MetricName [name=connection-close-total, group=remote-readonly-broker-4-remote-cluster-metadata-manager-localhost:9092-metrics, description=The total number of connections closed, tags={}]
	at org.apache.kafka.common.metrics.JmxReporter.addAttribute(JmxReporter.java:169) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.metrics.JmxReporter.metricChange(JmxReporter.java:127) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.metrics.Metrics.registerMetric(Metrics.java:597) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.metrics.Sensor.add(Sensor.java:300) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.metrics.Sensor.add(Sensor.java:280) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector$SelectorMetrics.<init>(Selector.java:1166) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector.<init>(Selector.java:178) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector.<init>(Selector.java:213) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector.<init>(Selector.java:225) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.network.Selector.<init>(Selector.java:229) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.RemoteBrokerBlockingSender.<init>(BrokerBlockingSender.scala:152) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.RemoteClusterMetadataManager.lambda$handleReadOnlyLeadersChanges$1(RemoteClusterMetadataManager.java:142) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1220) ~[?:?]
	at kafka.server.RemoteClusterMetadataManager.lambda$handleReadOnlyLeadersChanges$3(RemoteClusterMetadataManager.java:128) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at java.base/java.util.HashMap.forEach(HashMap.java:1421) ~[?:?]
	at kafka.server.RemoteClusterMetadataManager.handleReadOnlyLeadersChanges(RemoteClusterMetadataManager.java:127) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.RemoteClusterMetadataManager.onMetadataUpdate(RemoteClusterMetadataManager.java:100) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.metadata.BrokerMetadataPublisher.onMetadataUpdate(BrokerMetadataPublisher.scala:147) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.image.loader.MetadataLoader.maybePublishMetadata(MetadataLoader.java:345) ~[kafka-metadata-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.image.loader.MetadataBatchLoader.applyDeltaAndUpdate(MetadataBatchLoader.java:275) ~[kafka-metadata-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.image.loader.MetadataBatchLoader.maybeFlushBatches(MetadataBatchLoader.java:211) ~[kafka-metadata-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.image.loader.MetadataLoader.lambda$handleCommit$1(MetadataLoader.java:387) ~[kafka-metadata-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.queue.KafkaEventQueue$EventContext.run(KafkaEventQueue.java:133) [kafka-server-common-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.queue.KafkaEventQueue$EventHandler.handleEvents(KafkaEventQueue.java:216) [kafka-server-common-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.queue.KafkaEventQueue$EventHandler.run(KafkaEventQueue.java:187) [kafka-server-common-4.2.0-SNAPSHOT.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:842) [?:?]
Caused by: javax.management.MalformedObjectNameException: Invalid character ':' in value part of property
	at java.management/javax.management.ObjectName.construct(ObjectName.java:622) ~[?:?]
	at java.management/javax.management.ObjectName.<init>(ObjectName.java:1407) ~[?:?]
	at org.apache.kafka.common.metrics.JmxReporter$KafkaMbean.<init>(JmxReporter.java:225) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.common.metrics.JmxReporter.addAttribute(JmxReporter.java:164) ~[kafka-clients-4.2.0-SNAPSHOT.jar:?]
	... 25 more

```

2. Failure when deleting topics
```
[2025-09-03 17:31:39,417] ERROR Uncaught exception in scheduled task 'remote-cluster-metadata-refresh' (org.apache.kafka.server.util.KafkaScheduler)
java.lang.NullPointerException: Cannot invoke "org.apache.kafka.image.TopicImage.partitions()" because the return value of "org.apache.kafka.image.TopicsImage.getTopic(org.apache.kafka.common.Uuid)" is null
	at kafka.server.RemoteClusterMetadataManager.lambda$refreshRemoteMetadata$14(RemoteClusterMetadataManager.java:195) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511) ~[?:?]
	at kafka.server.RemoteClusterMetadataManager.lambda$refreshRemoteMetadata$15(RemoteClusterMetadataManager.java:189) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at java.base/java.util.HashMap.forEach(HashMap.java:1421) ~[?:?]
	at kafka.server.RemoteClusterMetadataManager.refreshRemoteMetadata(RemoteClusterMetadataManager.java:180) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at kafka.server.BrokerServer.$anonfun$startup$12(BrokerServer.scala:346) ~[kafka_2.13-4.2.0-SNAPSHOT.jar:?]
	at org.apache.kafka.server.util.KafkaScheduler.lambda$schedule$1(KafkaScheduler.java:151) ~[kafka-server-common-4.2.0-SNAPSHOT.jar:?]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) [?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:842) [?:?]

```

But after this change, the topic deletion is still failing. Let's figure it out later.
